### PR TITLE
Refactor of duplicate code

### DIFF
--- a/niri-config/src/lib.rs
+++ b/niri-config/src/lib.rs
@@ -1340,7 +1340,7 @@ impl Default for DndEdgeWorkspaceSwitch {
     }
 }
 
-#[derive(knuffel::Decode, Debug, Default, Clone, Copy, PartialEq)]
+#[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]
 pub struct HotCorners {
     #[knuffel(child)]
     pub off: bool,
@@ -1352,6 +1352,24 @@ pub struct HotCorners {
     pub bottom_left: bool,
     #[knuffel(child)]
     pub bottom_right: bool,
+}
+
+impl HotCorners {
+    pub fn is_enabled(&self) -> bool {
+        !self.off && (self.top_left || self.top_right || self.bottom_left || self.bottom_right)
+    }
+}
+
+impl Default for HotCorners {
+    fn default() -> Self {
+        Self {
+            off: false,
+            top_left: true,
+            top_right: false,
+            bottom_left: false,
+            bottom_right: false,
+        }
+    }
 }
 
 #[derive(knuffel::Decode, Debug, Clone, Copy, PartialEq)]
@@ -4819,7 +4837,7 @@ mod tests {
                 },
                 hot_corners: HotCorners {
                     off: false,
-                    top_left: false,
+                    top_left: true,
                     top_right: false,
                     bottom_left: false,
                     bottom_right: false,


### PR DESCRIPTION
Refactor and improvements of PR.

I also added a default for `top-left` so that the check here isn't necessary anymore: https://github.com/Fireye04/niri/blob/e5099c483cd102e27861008cad7a895ba292cd3b/src/niri.rs#L3147-L3153

I still don't know how to improve the monitor querying. It is quite a heavy request, especially for the fact that these function are called upon each mouse movement update. `let hot_corners = output.user_data().get::<HotCorners>()` is not possible.